### PR TITLE
make callback optional

### DIFF
--- a/lib/controllers/media.js
+++ b/lib/controllers/media.js
@@ -72,8 +72,11 @@ MediaController.prototype.load = function(media, options, callback) {
   });
 };
 
+function noop() {}
+
 MediaController.prototype.sessionRequest = function(data, callback) {
   data.mediaSessionId = this.currentSession.mediaSessionId;
+  callback = callback || noop;
 
   this.request(data, function(err, response) {
     if(err) return callback(err);


### PR DESCRIPTION
Hi Thibaut,

thank you for your great lib!
This change makes the callback optional. I needed to run `player.stop(function() {});` before.
