### PR TITLE
Add custom appId parameter to launch

### DIFF
--- a/lib/senders/default-media-receiver.js
+++ b/lib/senders/default-media-receiver.js
@@ -18,7 +18,7 @@ function DefaultMediaReceiver(client, session) {
 
 }
 
-DefaultMediaReceiver.APP_ID = 'CC1AD845';
+DefaultMediaReceiver.DEFAULT_APP_ID = 'CC1AD845';
 
 util.inherits(DefaultMediaReceiver, Application);
 

--- a/lib/senders/platform.js
+++ b/lib/senders/platform.js
@@ -88,14 +88,18 @@ PlatformSender.prototype.join = function(session, Application, callback) {
   callback(null, new Application(this.client, session));
 };
 
-PlatformSender.prototype.launch = function(Application, callback) {
+PlatformSender.prototype.launch = function(Application, appId, callback) {
   var self = this;
+  if (typeof appId !== 'string') {
+    callback = appId;
+    appId = Application.DEFAULT_APP_ID;
+  }
 
-  this.receiver.launch(Application.APP_ID, function(err, sessions) {
+  this.receiver.launch(appId, function(err, sessions) {
     if(err) return callback(err);
 
     var filtered = sessions.filter(function(session) {
-      return session.appId === Application.APP_ID;
+      return session.appId === appId;
     });
     var session = filtered.shift();
 


### PR DESCRIPTION
Hi there,
I've been using this excellent nodejs module, but wanted an easier way to launch with a StyledMediaReceiver AppID. So I added appId as an optional parameter to PlatformSender.launch. Let me know if it should be implemented another way or goes against your intentions for the design.