### PR TITLE
Don't emit an empty player status.

### DIFF
--- a/lib/controllers/media.js
+++ b/lib/controllers/media.js
@@ -15,6 +15,8 @@ function MediaController(client, sourceId, destinationId) {
   function onmessage(data, broadcast) {
     if(data.type === 'MEDIA_STATUS' && broadcast) {
       var status = data.status[0];
+      // Sometimes an empty status array can come through; if so don't emit it
+      if (!status) return;
       self.currentSession = status;
       self.emit('status', status);
     }


### PR DESCRIPTION
This can be potentially confusing for client applications and crashes the example code.

Sometimes, when streaming to a warm device, I'll see this `MEDIA_STATUS` message come down:

```
{ type: 'MEDIA_STATUS', status: [], requestId: 0 }
```

media.js then tries to pull out `data.status[0]` and emits a `'status'` event with an `undefined` payload.

This small patch simply holds off on emitting until there's actually data to emit, so users don't have to nullcheck on `'status'` events.