### PR TITLE
added LOAD_CANCELLED error to stop a crash

### DIFF
--- a/lib/controllers/media.js
+++ b/lib/controllers/media.js
@@ -75,7 +75,7 @@ MediaController.prototype.load = function(media, options, callback) {
       return callback(new Error('Load failed'));
     }
     if(response.type === 'LOAD_CANCELLED'){
-        return callback(new Error('Load cancelled'));
+      return callback(new Error('Load cancelled'));
     }
     var status = response.status[0];
     callback(null, status);

--- a/lib/controllers/media.js
+++ b/lib/controllers/media.js
@@ -74,7 +74,7 @@ MediaController.prototype.load = function(media, options, callback) {
     if(response.type === 'LOAD_FAILED') {
       return callback(new Error('Load failed'));
     }
-    if(response.type === 'LOAD_CANCELLED'){
+    if(response.type === 'LOAD_CANCELLED') {
       return callback(new Error('Load cancelled'));
     }
     var status = response.status[0];

--- a/lib/controllers/media.js
+++ b/lib/controllers/media.js
@@ -74,6 +74,9 @@ MediaController.prototype.load = function(media, options, callback) {
     if(response.type === 'LOAD_FAILED') {
       return callback(new Error('Load failed'));
     }
+    if(response.type === 'LOAD_CANCELLED'){
+        return callback(new Error('Load cancelled'));
+    }
     var status = response.status[0];
     callback(null, status);
   });


### PR DESCRIPTION
sometimes the load responses with LOAD_CANCELLED and this causes a crash since there isn't a response.status