### PR TITLE
Fixed eventlistener memory leak in castv2/lib/channel

### DIFF
--- a/lib/senders/default-media-receiver.js
+++ b/lib/senders/default-media-receiver.js
@@ -9,6 +9,8 @@ function DefaultMediaReceiver(client, session) {
   this.media = this.createController(MediaController);
 
   this.media.on('status', onstatus);
+  this.media.on('disconnect', ondisconnect);
+  this.on('close', onclose);
 
   var self = this;
 
@@ -16,6 +18,17 @@ function DefaultMediaReceiver(client, session) {
     self.emit('status', status);
   }
 
+  function ondisconnect() {
+    self.emit('close');
+  }
+
+  function onclose() {
+    self.removeListener('close', onclose);
+    self.media.removeListener('disconnect', ondisconnect);
+    self.media.removeListener('status', onstatus);
+    self.media.close();
+    self.media = null;
+  }
 }
 
 DefaultMediaReceiver.APP_ID = 'CC1AD845';


### PR DESCRIPTION
When creating multiple DefaultMediaReceivers the listeners from the previous MediaReceivers would not be cleaned up properly causing the following message: 
```
node) warning: possible EventEmitter memory leak detected. 11 message listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at Client.addListener (events.js:239:17)
    at new Channel (/node_modules/castv2/lib/channel.js:16:12)
    at Client.createChannel (/node_modules/castv2/lib/client.js:132:10)
    at MediaController.Controller (/node_modules/castv2-client/lib/controllers/controller.js:8:25)
    at MediaController.JsonController (/node_modules/castv2-client/lib/controllers/json.js:6:14)
    at MediaController.RequestResponseController (/node_modules/castv2-client/lib/controllers/request-response.js:6:18)
    at new MediaController (/node_modules/castv2-client/lib/controllers/media.js:6:29)
    at MediaController.fn (/node_modules/castv2-client/lib/senders/sender.js:29:23)
    at construct (/node_modules/castv2-client/lib/senders/sender.js:32:10)
    at DefaultMediaReceiver.Sender.createController (/node_modules/castv2-client/lib/senders/sender.js:24:10)
    at new DefaultMediaReceiver (/node_modules/castv2-client/lib/senders/default-media-receiver.js:9:21)
    at PlatformSender.join (/node_modules/castv2-client/lib/senders/platform.js:92:18)
    at /node_modules/castv2-client/lib/senders/platform.js:106:10
    at /node_modules/castv2-client/lib/controllers/receiver.js:53:5
    at ReceiverController.onmessage (/node_modules/castv2-client/lib/controllers/request-response.js:27:7)
    at emitTwo (events.js:92:20)
    at ReceiverController.emit (events.js:172:7)
    at Channel.onmessage (/node_modules/castv2-client/lib/controllers/controller.js:16:10)
    at emitTwo (events.js:87:13)
    at Channel.emit (events.js:172:7)
    at Client.onmessage (/node_modules/castv2/lib/channel.js:23:10)
    at emitMany (events.js:113:20)
    at Client.emit (events.js:182:7)
    at PacketStreamWrapper.onpacket (/node_modules/castv2/lib/client.js:81:10)
    at emitOne (events.js:77:13)
    at PacketStreamWrapper.emit (events.js:169:7)
    at TLSSocket.<anonymous> (/node_modules/castv2/lib/packet-stream-wrapper.js:28:16)
    at emitNone (events.js:67:13)
    at TLSSocket.emit (events.js:166:7)
    at emitReadable_ (_stream_readable.js:419:10)
    at emitReadable (_stream_readable.js:413:7)
    at readableAddChunk (_stream_readable.js:164:13)
    at TLSSocket.Readable.push (_stream_readable.js:111:10)
    at TLSWrap.onread (net.js:536:20)
```

I've added an onDisconnectListener and onCloseListener to DefaultMediaReceiver to propegate the close event to the MediaController so all old listeners will be removed.