### PR TITLE
Added null check for current session

### DIFF
--- a/lib/controllers/media.js
+++ b/lib/controllers/media.js
@@ -85,6 +85,10 @@ MediaController.prototype.load = function(media, options, callback) {
 function noop() {}
 
 MediaController.prototype.sessionRequest = function(data, callback) {
+  if (this.currentSession == null) {
+    callback(new Error('No current session'));
+  }
+  
   data.mediaSessionId = this.currentSession.mediaSessionId;
   callback = callback || noop;
 


### PR DESCRIPTION
media call fails silently when currentSession is null. This happens when no media is playing, rather then silently failing I added a null check and error callback.