### PR TITLE
add self to connect callback

### DIFF
--- a/lib/senders/platform.js
+++ b/lib/senders/platform.js
@@ -58,7 +58,7 @@ PlatformSender.prototype.connect = function(options, callback) {
 
     self.connection.connect();
     self.heartbeat.start();
-    callback();
+    callback( self );
   });
 };
 


### PR DESCRIPTION
I'm trying to use multiple clients to multiple chromecasts. It would be very handy (and very easy!) if the connect callback would contain a reference to the client. I achieved this by adding the 'self' object as argument to the 'callback()' call