### PR TITLE
Fix headers in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install castv2-client --no-optional
 Examples
 --------
 
-###Launching a stream on the device
+### Launching a stream on the device
 
 ``` javascript
 var Client                = require('castv2-client').Client;
@@ -97,7 +97,7 @@ function ondeviceup(host) {
 }
 ```
 
-###Other examples
+### Other examples
 
 Check the examples directory.
 


### PR DESCRIPTION
Some of the third level headers didn't have a space between the hashtags and the text, so this PR fixes that