### PR TITLE
Fix sessionRequest function

### DIFF
--- a/lib/controllers/media.js
+++ b/lib/controllers/media.js
@@ -90,6 +90,7 @@ MediaController.prototype.sessionRequest = function(data, callback) {
 
   this.request(data, function(err, response) {
     if(err) return callback(err);
+    if(typeof(response.status) == 'undefined') return callback(response.reason || 'unknown response');
     var status = response.status[0];
     callback(null, status);
   });


### PR DESCRIPTION
Under some circunstances, the value of "response" at the line 93 will be:

{type: "ERROR", reason: "APP_ERROR"}

...with no "status" attribute, possibly causing the process to crash.